### PR TITLE
Using `check_array` to be compatible with sklearn 0.16.1+

### DIFF
--- a/pegasos/base.py
+++ b/pegasos/base.py
@@ -68,7 +68,7 @@ class PegasosBase(BaseEstimator, ClassifierMixin):
         # training algorithm requires the labels to be -1 and +1.
         y[y==0] = -1
 
-        X = atleast2d_or_csr(X, dtype=np.float64, order="C")
+        X = check_array(X, dtype=np.float64, order="C")
 
         if X.shape[0] != y.shape[0]:
             raise ValueError("X and y have incompatible shapes.\n"

--- a/pegasos/base.py
+++ b/pegasos/base.py
@@ -14,18 +14,24 @@
     limitations under the License.
 """
 
-
+import warnings
 from abc import ABCMeta, abstractmethod
+
+import numpy as np
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.preprocessing import LabelEncoder
-from sklearn.utils import atleast2d_or_csr
+try:
+    from sklearn.utils import check_array
+except ImportError as e:
+    warnings.warn(str(e)+'\n'
+                  + '`from sklearn.utils import check_array` failed.\n'
+                  + 'Using `from sklearn.utils import atleast2d_or_csr` instead.')
+    from sklearn.utils import atleast2d_or_csr as check_array
 from scipy import sparse
 
 from . import pegasos, constants
 from .weight_vector import WeightVector
 
-import numpy as np
-import warnings
 
 class PegasosBase(BaseEstimator, ClassifierMixin):
     __metaclass__ = ABCMeta
@@ -113,4 +119,3 @@ class PegasosBase(BaseEstimator, ClassifierMixin):
         if not hasattr(self, '_enc'):
             raise ValueError('must call `fit` before `classes_`')
         return self._enc.classes_
-


### PR DESCRIPTION
Due to the absence of `atleast2d_or_csr` in newer scikit-learn versions, I added `check_array`. Compatibility to older versions through try-except fallback to the old name with user warning. 

[Pegasos Issue](https://github.com/ejlb/pegasos/issues/2)
[Sklearn Issue](https://github.com/scikit-learn/scikit-learn/issues/6587)